### PR TITLE
Update MDB2.php … PHP 8.3でのWarning対応（$positions）

### DIFF
--- a/MDB2.php
+++ b/MDB2.php
@@ -4179,6 +4179,7 @@ class MDB2_Statement_Common
 
     var $db;
     var $statement;
+    var $positions;
     var $query;
     var $result_types;
     var $types;


### PR DESCRIPTION
Warning内容：
`PHP Deprecated:  Creation of dynamic property MDB2_Statement_pgsql::$positions is deprecated in /var/www/data/vendor/nanasess/mdb2/MDB2.php on line 4200`