### PR TITLE
Update MDB2.php … PHP 8.3でのWarning対応２（$loaded_version_modules）

### DIFF
--- a/MDB2.php
+++ b/MDB2.php
@@ -1338,6 +1338,13 @@ class MDB2_Driver_Common
     protected $modules = array();
 
     /**
+     * array of loaded version modules instances
+     * @var     array
+     * @access  protected
+     */
+    protected $loaded_version_modules = array();
+
+    /**
      * determines of the PHP4 destructor emulation has been enabled yet
      * @var     array
      * @access  protected


### PR DESCRIPTION
Warning内容：
```
PHP Deprecated:  Creation of dynamic property MDB2_Driver_pgsql::$loaded_version_modules is deprecated in /var/www/data/vendor/nanasess/mdb2/MDB2.php on line 1952
```